### PR TITLE
Update 029_make_journald_persistent.md

### DIFF
--- a/questions/029_make_journald_persistent.md
+++ b/questions/029_make_journald_persistent.md
@@ -17,8 +17,10 @@ Configure **journald** to persist between reboots
  Enabling it to be persistent is pretty straightforward:
 
 ```
-mkdir -p /var/log/journal
-systemctl restart systemd-journald
+#edit the file /etc/systemd/journald.conf and change "#Storage=auto" to "Storage=persistent"
+systemctl restart systemd-journald.service
 ```
 
 and that's all. After reboot all logs will still be there.
+# From man journald.conf:
+# ... Storage= Controls where to store journal data. ... If "persistent", data will be stored preferably on disk, i.e. below the /var/log/journal hierarchy (which is created if needed), with a fallback to /run/log/journal (which is created if needed), during early boot and if the disk is not writable. "auto" behaves like "persistent" if the /var/log/journal directory exists, and "volatile" otherwise (the existence of the directory controls the storage mode)."


### PR DESCRIPTION
man journald.conf 
"Storage= Controls where to store journal data. ... If "persistent", data will be stored preferably on disk, i.e. below the /var/log/journal hierarchy (which is created if needed), with a fallback to /run/log/journal (which is created if needed), during early boot and if the disk is not writable."

So just editing the file /etc/systemd/journald.conf and changing "#Storage=auto" to "Storage=persistent" works without having to memorize which directory has to be created, which is a common error. The directory is created by the service automatically once "persistent" is selected.

I also added ".service" to the systemctl command because it is more accurate this way.