### PR TITLE
Fix command used for search

### DIFF
--- a/questions/032_finding_files_with_given_text_in_them.md
+++ b/questions/032_finding_files_with_given_text_in_them.md
@@ -14,7 +14,7 @@ Find All Files in ***/etc*** (not subdirectories) that contain text "chrony" (ig
 * For browsing file's contents the main command is **grep**. Below is the simple one-liner.
 
 ```
-grep -is chrony /etc/
+grep -lis chrony /etc/*
 ```
 
 


### PR DESCRIPTION
In order to get paths `-l` option is needed. On top of that we want to look at the contents of `/etc`, not the directory as a file itself