### PR TITLE
Update 008_create_users_with_specified_uid.md

### DIFF
--- a/questions/008_create_users_with_specified_uid.md
+++ b/questions/008_create_users_with_specified_uid.md
@@ -37,14 +37,15 @@ Maximum number of days between password change          : 99999
 Number of days of warning before password expires       : 7
 ```
 
-* Given that we know the current date we can set expiry date manually:
+* Given that we know the current date we can set expiry date manually by copying the following from the chage man pages:
 
 ```
-chage -E 2019-10-14 davis
+man chage
+chage -E $(date -d +30days +%Y-%m-%d)
 ```
 
 ### Additional comment:
-
+Using "man chage" and scrolling down a bit you can copy and paste the command above without memorizing it and just simply paste the number of days you want to add until the account expires.
 Remember there is a difference between **password expiration** and **account validation**. It is usually better to expire password and 
 make user not being able to log into the system or disable the user, rather than deleting it.
 


### PR DESCRIPTION
Switched the existing working command for a command that can be copied from the man pages and that allows users to just paste the amount of days they wish to have added until account expiration. Copy-paste means less room for error and just adding the amount of days takes away the risk of typing the date out wrong or making a mistake when adding a month to today's date.