### PR TITLE
Fix size of the partition to create

### DIFF
--- a/questions/017_create_physical_partition_and_mount.md
+++ b/questions/017_create_physical_partition_and_mount.md
@@ -43,7 +43,7 @@ parted /dev/something
 using it as a target create new **logical** partition on it (up to the total number of **15**).
 
 * Editor will be opened where You choose **n** to create new partition, we prompt the start of block size, then to easy things
-just provide **+100M** value (instead of using blocks) and then remember to write the changes to the partition table by pressing
+just provide **+100MB** value (instead of using blocks) and then remember to write the changes to the partition table by pressing
 **w**. Then quit.
 
 * We should let know the kernel that partition table was changed (compare **fdisk -l /link/to/disc** with **cat /proc/partitions**).


### PR DESCRIPTION
In order to create a partition of size 100MB (which was described in the exercise's description) we need to provide `+100MB` as the parameter to fdisk, `+100M` results in creating a partition of 100M<b>i</b>B

<img width="1537" alt="Screenshot 2021-03-27 at 13 55 25" src="https://user-images.githubusercontent.com/24464340/112721573-d7514200-8f04-11eb-97f5-4b6196519aca.png">


Also, don't you think that it would be better to precisely state in the exercise that it should be mounted permanently?