### PR TITLE
Add linger enablement step, use redirection to save the config

### DIFF
--- a/questions/034_containers.md
+++ b/questions/034_containers.md
@@ -2,8 +2,9 @@
 
 ### Question
 Login to the registry.
-Download image for a webserver. 
-Run web server in a container as a user-service on port 8080, sharing files from /home/user/webfiles
+Download image of a web server. 
+Run the web server in a container as a user-service on port 8080, sharing files from /home/user/webfiles.
+Ensure the web server is available across reboots.
 
 ***
 (scroll down for an answer)
@@ -13,16 +14,46 @@ Run web server in a container as a user-service on port 8080, sharing files from
 
 ### Answer:
 
-root$ podman login  
-user$ podman create . f.e. podman create docker.io/library/httpd as I don't have any local registry present  
-user$ podman run -d -v /home/user/webfiles:/usr/local/apache2/htdocs -p 8080:80 --name user_httpd docker.io/library/httpd  
-user$ sudo podman generate systemd user_httpd -o /etc/systemd/user/user_httpd.service (or just copy output if user is not sudoer)  
-user$ systemctl --user enable --now user_httpd.service (you need to be logged in as a user, not just su to it)  
-  
-Add SELinux permissions to the catalog   
-root# semanage fcontext -at container_file_t "/home/admin/user(/.*)?"  
-root# restorecon -vR /home/admin/webfiles  
-  
-Add port to the firewall  
-root# firewall-cmd --add-port=8080/tcp --permanent  
-root# firewall-cmd --reload  
+* Switch to the account of user that will be running the container.
+It is assumed that user named `user` exists on the system
+```
+# su - user
+```
+* Authenticate if you have a private registry with images to work with. 
+To let anyone do the exercise public repository is used through the rest of steps
+``` 
+$ podman login 
+```
+* Create the container
+```
+$ podman create -d -v /home/user/webfiles:/usr/local/apache2/htdocs -p 8080:80 --name user_httpd docker.io/library/httpd
+```
+* Generate service configuration
+```
+$ sudo podman generate systemd user_httpd > ~/.config/systemd/user/user_httpd.service
+```
+* Enable and start the service. You need to be logged in as the user, switching to it is not enough
+```
+$ systemctl --user enable --now user_httpd.service
+```
+* Enable linger, otherwise start of the container would happen when the user logs in
+```
+$ loginctl enable-linger
+```
+
+* Add SELinux permissions to the catalog
+```
+# semanage fcontext -at container_file_t "/home/user/webfiles(/.*)?"
+# restorecon -vR /home/user/webfiles
+```
+Alternatively, while creating the container you could configure volume and let podman take care of setting the context up for you.
+Syntax looks as follows:
+```
+$ podman run -v <src>:<dst>:z <image>
+```
+
+* Add port to the firewall
+```
+# firewall-cmd --add-port=8080/tcp --permanent
+# firewall-cmd --reload
+```


### PR DESCRIPTION
What has been done:
* Used redirection instead of `-o` to save service configuration from podman. In the latest version this option is not supported
* I've added step of linger enablement. Without it the web server will not be available after a reboot untill the user logs in
* Code enclosed in snippets 
* There was a reference to the user `admin`, I changed all mentiones to `user` for consistency